### PR TITLE
Replace deprecated function time.clock() for Python 3.8 compatibility

### DIFF
--- a/reggie.py
+++ b/reggie.py
@@ -1478,7 +1478,7 @@ class LevelUnit():
 
     def loadLevel(self, name, fullpath, area, progress=None):
         """Loads a specific level and area"""
-        startTime = time.clock()
+        startTime = time.process_time()
 
         # read the archive
         if fullpath:
@@ -1598,7 +1598,7 @@ class LevelUnit():
         if l2 is not None:
             self.LoadLayer(2,l2)
 
-        endTime = time.clock()
+        endTime = time.process_time()
         total = endTime - startTime
         #print('Level loaded in %f seconds' % total)
 


### PR DESCRIPTION
The program would not run with Python 3.8.1 due to the removal of the deprecated `time.clock()` function from python 3.8. I fixed it by changing it to [`time.process_time()`](https://docs.python.org/3/library/time.html#time.process_time), which appears to be most appropriate here.
> The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior.

https://docs.python.org/3/whatsnew/3.8.html

