### PR TITLE
Fixed issue to allow running reggie.py from any folder.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ Other Testers and Contributors
 ------------------------------
 - BulletBillTime, Dirbaio, EdgarAllen, FirePhoenix, GrandMasterJimmy,
   Mooseknuckle2000, MotherBrainsBrain, RainbowIE, Skawo, Sonicandtails,
-  Tanks, Vibestar
+  Tanks, Vibestar, Kitty-Cats
 - Tobias Amaranth and Valeth — Text Tileset Addon
 
 

--- a/reggie.py
+++ b/reggie.py
@@ -29,6 +29,7 @@ import struct
 import sys
 import time
 import warnings
+import pathlib
 from xml.dom import minidom
 
 try:
@@ -154,7 +155,7 @@ def module_path():
             return os.path.join(os.path.dirname(macos), 'Resources')
 
     if __name__ == '__main__':
-        return os.path.dirname(os.path.abspath(sys.argv[0]))
+        return pathlib.Path(__file__).resolve().parent
 
     return None
 

--- a/reggie.py
+++ b/reggie.py
@@ -29,7 +29,6 @@ import struct
 import sys
 import time
 import warnings
-import pathlib
 from xml.dom import minidom
 
 try:
@@ -155,7 +154,7 @@ def module_path():
             return os.path.join(os.path.dirname(macos), 'Resources')
 
     if __name__ == '__main__':
-        return pathlib.Path(__file__).resolve().parent
+        return os.path.dirname(os.path.abspath(sys.argv[0]))
 
     return None
 

--- a/reggie.py
+++ b/reggie.py
@@ -154,7 +154,7 @@ def module_path():
             return os.path.join(os.path.dirname(macos), 'Resources')
 
     if __name__ == '__main__':
-        return os.path.dirname(os.path.abspath(sys.argv[0]))
+        return os.path.dirname(os.path.abspath(__file__))
 
     return None
 


### PR DESCRIPTION
Fixed module_path not returning the correct path if run from outside `Reggie-Updated` folder.

### TL;DR
`module_path` only returned the correct path when running `reggie.py` from inside the `Reggie-Updated` folder. This made `reggie.py` act as if the `reggiedata` folder was missing when running from outside the `Reggie-Updated` folder. 
**Fixed using `pathlib`.**

### Bug Details
This bug was present on both MacOS 10.14.6 & Ubuntu 20.04, Based on the code the issue should also have occurred on Windows. This fix has been tested on both MacOS 10.14.6 & Ubuntu 20.04, and has worked on both operating systems.

The following shows the original behaviour of `module_path`. The expected output of '2' should have been `/Users/joshua/PycharmProjects/Reggie-Updated/`. reggie.py was run from `/Users/joshua/PycharmProjects/` and the `Reggie-Updated` folder was located under `PycharmProjects`.

Here's an example of how I diagnosed the problem.
**The debugging code has since been removed.**
```
File: reggie.py
Function: def module_path():

    if __name__ == '__main__':
        print("1====================================")
        print(sys.argv[0])
        print("2====================================")
        print(os.path.abspath(sys.argv[0]))
        return os.path.dirname(os.path.abspath(sys.argv[0]))
```
Here is the output of `reggie.py` when ran from `/Users/joshua/PycharmProjects/` with the above debugging code included. This is wrong because the folder in which `reggie.py` is located is named `Reggie-Updated` and not `Reggie! Level Editor`. `module_path` was supposed to return the absolute path of `reggie.py` but instead returns the current working directory path + `Reggie! Level Editor`. Because of this, the program only works if launched from the `Reggie-Updated` folder.
```
1====================================
Reggie! Level Editor
2====================================
/Users/joshua/PycharmProjects/Reggie! Level Editor
```
This an example of the error reggie gives when run outside of the `Reggie-Updated` folder:
<img width="415" alt="Screen Shot 2020-09-13 at 2 48 28 PM" src="https://user-images.githubusercontent.com/19499022/93009416-ee69bb80-f5d4-11ea-8370-55043c5a5d14.png">

These problems have been resolved in the pull request.

### To reproduce(on Linux/MacOS):

1. Git clone Reggie-Updated & `git reset --hard 7f9a67a`
2. cd to an directory outside the folder. Eg. `cd Reggie-Updated/..` 
3. Run reggie.py from outside the folder. Eg.`python3 Reggie-Updated/reggie.py` This should produce the above error.
4. Compare this with running it *inside* the folder. Eg. `cd Reggie-Updated; python3 ./reggie.py` This should work as expected.
