### PR TITLE
Reposition path node and entrance text

### DIFF
--- a/reggie.py
+++ b/reggie.py
@@ -3153,8 +3153,8 @@ class PathEditorItem(LevelEditorItem):
         icontype = 0
 
         painter.setFont(self.font)
-        painter.drawText(4,11,str(self.pathid))
-        painter.drawText(4,9 + QtGui.QFontMetrics(self.font).height(),str(self.nodeid))
+        painter.drawText(3,12,str(self.pathid))
+        painter.drawText(3,22,str(self.nodeid))
         painter.drawPoint(self.objx, self.objy)
 
         if self.isSelected():

--- a/reggie.py
+++ b/reggie.py
@@ -3153,8 +3153,8 @@ class PathEditorItem(LevelEditorItem):
         icontype = 0
 
         painter.setFont(self.font)
-        painter.drawText(3,12,str(self.pathid))
-        painter.drawText(3,22,str(self.nodeid))
+        painter.drawText(4,7+(QtGui.QFontMetrics(self.font).ascent()*2/3)/2,str(self.pathid))
+        painter.drawText(4,17+(QtGui.QFontMetrics(self.font).ascent()*2/3)/2,str(self.nodeid))
         painter.drawPoint(self.objx, self.objy)
 
         if self.isSelected():

--- a/reggie.py
+++ b/reggie.py
@@ -3039,7 +3039,8 @@ class EntranceEditorItem(LevelEditorItem):
 
         #painter.drawText(self.BoundingRect,QtCore.Qt.AlignLeft,str(self.entid))
         painter.setFont(self.font)
-        painter.drawText(3,12,str(self.entid))
+        fontheight = QtGui.QFontMetrics(self.font).ascent() * 2/3
+        painter.drawText(QtCore.QPointF(3,7+fontheight/2),str(self.entid))
 
         if self.isSelected():
             #painter.setRenderHint(QtGui.QPainter.Antialiasing, False)
@@ -3153,8 +3154,9 @@ class PathEditorItem(LevelEditorItem):
         icontype = 0
 
         painter.setFont(self.font)
-        painter.drawText(4,7+(QtGui.QFontMetrics(self.font).ascent()*2/3)/2,str(self.pathid))
-        painter.drawText(4,17+(QtGui.QFontMetrics(self.font).ascent()*2/3)/2,str(self.nodeid))
+        fontheight = QtGui.QFontMetrics(self.font).ascent() * 2/3
+        painter.drawText(QtCore.QPointF(4,7+fontheight/2),str(self.pathid))
+        painter.drawText(QtCore.QPointF(4,17+fontheight/2),str(self.nodeid))
         painter.drawPoint(self.objx, self.objy)
 
         if self.isSelected():


### PR DESCRIPTION
Since all three OSes (Win, Mac, Linux) use different fonts, Reggie's hardcoded vertical positioning could never look good on all of them at once.

This change makes it actually properly vertically center the text in (the top or bottom half of) the box instead, using the height of the current number font. Tested and looks good on all three OSes.