### PR TITLE
GitHub Actions: caching on macOS and other small improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,13 @@ jobs:
         cd ..
     - name: Make Python symlink (macOS)
       if: ${{ matrix.platform == 'macos-latest' }}
-      run: ln -s python/build/bin/python3 ./python3
+      run: |
+        echo "ls .:"
+        ls .
+        echo "ls python:"
+        ls python
+        echo "making symlink:"
+        ln -s python/build/bin/python3 ./python3
     - name: Set up Python (Windows/Linux)
       if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,9 +71,9 @@ jobs:
         ls python/build/bin
         echo "some more stuff:"
         echo $(pwd)
-        echo $(readlink python/build/bin/python3)
+        echo $(readlink ./python/build/bin/python3)
         echo "making symlink:"
-        ln -s python/build/bin/python3 ./python3
+        ln -s ./python/build/bin/python3 ./python3
         echo "testing symlink:"
         ./python3 -c "import sys; print(sys.version)"
     - name: Set up Python (Windows/Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         cd src
         cd *
         mv ./* ../../
-    - name: Build Python and make symlink (macOS)
+    - name: Build Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         cd python
@@ -60,7 +60,9 @@ jobs:
         make
         sudo make install
         cd ..
-        ln -s python/build/bin/python3 ./python3
+    - name: Make Python symlink (macOS)
+      if: ${{ matrix.platform == 'macos-latest' }}
+      run: ln -s python/build/bin/python3 ./python3
     - name: Set up Python (Windows/Linux)
       if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       if: ${{ matrix.platform == 'macos-latest' }}
       uses: actions/cache@v2
       with:
-        path: ./python
+        path: ['./python', '/Library/Frameworks/Python.framework/Versions/3.9']
         key: macos-python-${{ env.manual-python-version }}-AAA
     - name: Download Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
@@ -58,7 +58,7 @@ jobs:
         export MACOSX_DEPLOYMENT_TARGET=10.13
         ./configure --enable-optimizations --enable-framework --with-openssl=$(brew --prefix openssl) "--prefix=$(pwd)/build"
         make
-        sudo make altinstall
+        sudo make install
         brew install coreutils
         echo "DID MAKE ALTINSTALL -- HERE'S SOME THINGS:"
         echo $(pwd)
@@ -91,7 +91,7 @@ jobs:
         ls python/build/bin
         echo "some more stuff:"
         echo $(pwd)
-        echo $(readlink ./python/build/bin/python3)
+        echo $(greadlink -f ./python/build/bin/python3)
         echo "making symlink:"
         ln -s ./python/build/bin/python3 ./python3
         echo "testing symlink:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9]  # Don't forget to also change the hardcoded Python source code download URL for macOS!
+        python-version: [3.9]  # Don't forget to also change the "manual-python-version" numbers below!
         platform: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
     env:
-      manual-python-version: 3.9
+      manual-python-version: 3.9  # Don't forget to also change the matrix "python-version" number above!
       manual-python-version-full: 3.9.0
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         path: |
           ./python
           ./python-framework
-        key: macos-python-${{ env.manual-python-version-full }}-AAB
+        key: macos-python-${{ env.manual-python-version-full }}
     - name: Download Python (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
@@ -65,8 +65,7 @@ jobs:
         cd ..
     - name: Copy Python for caching (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
-      run: |
-        cp -r /Library/Frameworks/Python.framework/Versions/${{ env.manual-python-version }} ./python-framework
+      run: cp -r /Library/Frameworks/Python.framework/Versions/${{ env.manual-python-version }} ./python-framework
     - name: Un-copy Python from cache (macOS, cache hit)
       if: ${{ matrix.platform == 'macos-latest' && steps.caching.outputs.cache-hit }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./python
-        key: macos-python-${{ env.manual-python-version }}-XXX
+        key: macos-python-${{ env.manual-python-version }}-AAA
     - name: Download Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,12 @@ jobs:
         ls .
         echo "ls python:"
         ls python
+        echo "ls python/build/bin:"
+        ls python/build/bin
         echo "making symlink:"
         ln -s python/build/bin/python3 ./python3
+        echo "testing symlink:"
+        ./python3 -c "import sys; print(sys.version)"
     - name: Set up Python (Windows/Linux)
       if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,22 @@ jobs:
         ./configure --enable-optimizations --enable-framework --with-openssl=$(brew --prefix openssl) "--prefix=$(pwd)/build"
         make
         sudo make altinstall
-        echo "DID MAKE ALTINSTALL -- HERE'S THE READLINK:"
+        echo "DID MAKE ALTINSTALL -- HERE'S SOME THINGS:"
+        echo $(pwd)
+        echo $(readlink .)
+        echo "BEGIN LS"
+        ls .
+        echo "-------------------- A"
+        echo $(readlink ./build)
+        echo "BEGIN LS"
+        ls ./build
+        echo "-------------------- B"
+        echo $(readlink ./build/bin)
+        echo "BEGIN LS"
+        ls ./build/bin
+        echo "-------------------- C"
         echo $(readlink ./build/bin/python3)
+        echo "END ALL"
         cd ..
     - name: Make Python symlink (macOS)
       if: ${{ matrix.platform == 'macos-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,33 @@ jobs:
         platform: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
+    env:
+      manual-python-version: 3.9.0
+
     steps:
     - name: Set environment variables (Windows/Linux)
+      if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
       shell: bash
       run: echo "PYTHON_CMD=python" >> $GITHUB_ENV
-      if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
     - name: Set environment variables (macOS)
-      run: echo "PYTHON_CMD=./python3" >> $GITHUB_ENV
       if: ${{ matrix.platform == 'macos-latest' }}
+      run: echo "PYTHON_CMD=./python3" >> $GITHUB_ENV
     - name: Checkout repository
       uses: actions/checkout@v2
+    - name: Cache Python build (macOS)
+      id: caching
+      if: ${{ matrix.platform == 'macos-latest' }}
+      uses: actions/cache@v2
+      with:
+        path: ./python
+        key: macos-python-${{ env.manual-python-version }}
     - name: Download Python (macOS)
+      if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         # Do all this in a "python" subfolder
         mkdir python && cd python
         # Download Python source and unzip into /src subfolder
-        curl -o Python.tar.xz https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+        curl -o Python.tar.xz https://www.python.org/ftp/python/${{ env.manual-python-version }}/Python-${{ env.manual-python-version }}.tar.xz
         mkdir src
         tar -xf Python.tar.xz -C ./src
         # All the source code is annoyingly in e.g. /src/Python-3.9.0/ or similar, so let's
@@ -38,8 +49,8 @@ jobs:
         cd src
         cd *
         mv ./* ../../
-      if: ${{ matrix.platform == 'macos-latest' }}
     - name: Build Python and make symlink (macOS)
+      if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         cd python
         mkdir build
@@ -50,12 +61,11 @@ jobs:
         sudo make install
         cd ..
         ln -s python/build/bin/python3 ./python3
-      if: ${{ matrix.platform == 'macos-latest' }}
     - name: Set up Python (Windows/Linux)
+      if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-      if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
     - name: Install dependencies other than PyInstaller
       shell: bash
       run: |
@@ -63,11 +73,12 @@ jobs:
         $PYTHON_CMD -m pip install wheel
         $PYTHON_CMD -m pip install PyQt5 nsmblib
     - name: Install PyInstaller (Windows/Linux)
+      if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
       shell: bash
       run: |
         $PYTHON_CMD -m pip install PyInstaller
-      if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
     - name: Build and install PyInstaller (macOS)
+      if: ${{ matrix.platform == 'macos-latest' }}
       run: |
         git clone https://github.com/pyinstaller/pyinstaller
         cd pyinstaller/bootloader
@@ -79,25 +90,24 @@ jobs:
         ../.././python3 ./waf all
         cd ..
         .././python3 -m pip install .
-      if: ${{ matrix.platform == 'macos-latest' }}
     - name: Build
       shell: bash
       run: $PYTHON_CMD -OO build_release.py
     - name: Tar (macOS/Linux)
+      if: ${{ matrix.platform == 'macos-latest' || matrix.platform == 'ubuntu-latest' }}
       run: |
         cd distrib
         tar -czvf ../build-${{ matrix.platform }}.tar.gz ./*
         cd ..
-      if: ${{ matrix.platform == 'macos-latest' || matrix.platform == 'ubuntu-latest' }}
     - name: Upload artifacts (Windows)
+      if: ${{ matrix.platform == 'windows-latest' }}
       uses: actions/upload-artifact@v2
       with:
         name: build-${{ matrix.platform }}
         path: distrib/*
-      if: ${{ matrix.platform == 'windows-latest' }}
     - name: Upload artifacts (macOS/Linux)
+      if: ${{ matrix.platform == 'macos-latest' || matrix.platform == 'ubuntu-latest' }}
       uses: actions/upload-artifact@v2
       with:
         name: build-${{ matrix.platform }}
         path: build-${{ matrix.platform }}.tar.gz
-      if: ${{ matrix.platform == 'macos-latest' || matrix.platform == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
         echo "-------------------- C"
         python -c "import os; print(os.path.realpath('./build/bin/python3'))"
         greadlink -f ./build/bin/python3
+        python -c "import os; print(os.path.realpath('./build/bin/python3.9'))"
+        greadlink -f ./build/bin/python3.9
         echo "END ALL"
         cd ..
     - name: Make Python symlink (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
       if: ${{ matrix.platform == 'macos-latest' }}
       uses: actions/cache@v2
       with:
-        path: ['./python', '/Library/Frameworks/Python.framework/Versions/3.9']
+        path:
+          - './python'
+          - '/Library/Frameworks/Python.framework/Versions/3.9'
         key: macos-python-${{ env.manual-python-version }}-AAA
     - name: Download Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./python
-        key: macos-python-${{ env.manual-python-version }}
+        key: macos-python-${{ env.manual-python-version }}-XXX
     - name: Download Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
@@ -58,7 +58,9 @@ jobs:
         export MACOSX_DEPLOYMENT_TARGET=10.13
         ./configure --enable-optimizations --enable-framework --with-openssl=$(brew --prefix openssl) "--prefix=$(pwd)/build"
         make
-        sudo make install
+        sudo make altinstall
+        echo "DID MAKE ALTINSTALL -- HERE'S THE READLINK:"
+        echo $(readlink ./build/bin/python3)
         cd ..
     - name: Make Python symlink (macOS)
       if: ${{ matrix.platform == 'macos-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,9 @@ jobs:
         ls python
         echo "ls python/build/bin:"
         ls python/build/bin
+        echo "some more stuff:"
+        echo $(pwd)
+        echo $(readlink python/build/bin/python3)
         echo "making symlink:"
         ln -s python/build/bin/python3 ./python3
         echo "testing symlink:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,19 +61,19 @@ jobs:
         sudo make altinstall
         echo "DID MAKE ALTINSTALL -- HERE'S SOME THINGS:"
         echo $(pwd)
-        echo $(readlink .)
+        python -c "import os; print(os.path.realpath('.'))"
         echo "BEGIN LS"
         ls .
         echo "-------------------- A"
-        echo $(readlink ./build)
+        python -c "import os; print(os.path.realpath('./build'))"
         echo "BEGIN LS"
         ls ./build
         echo "-------------------- B"
-        echo $(readlink ./build/bin)
+        python -c "import os; print(os.path.realpath('./build/bin'))"
         echo "BEGIN LS"
         ls ./build/bin
         echo "-------------------- C"
-        echo $(readlink ./build/bin/python3)
+        python -c "import os; print(os.path.realpath('./build/bin/python3'))"
         echo "END ALL"
         cd ..
     - name: Make Python symlink (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         path: |
           ./python
           ./python-framework
+          ~/Library/Python/3.9
         key: macos-python-${{ env.manual-python-version-full }}
     - name: Download Python (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,9 @@ jobs:
       if: ${{ matrix.platform == 'macos-latest' }}
       uses: actions/cache@v2
       with:
-        path:
-          - './python'
-          - '/Library/Frameworks/Python.framework/Versions/3.9'
+        path: |
+          ./python
+          /Library/Frameworks/Python.framework/Versions/3.9
         key: macos-python-${{ env.manual-python-version }}-AAA
     - name: Download Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     env:
-      manual-python-version: 3.9.0
+      manual-python-version: 3.9
+      manual-python-version-full: 3.9.0
 
     steps:
     - name: Set environment variables (Windows/Linux)
@@ -36,14 +37,14 @@ jobs:
         path: |
           ./python
           ./python-framework
-        key: macos-python-${{ env.manual-python-version }}-AAB
+        key: macos-python-${{ env.manual-python-version-full }}-AAB
     - name: Download Python (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         # Do all this in a "python" subfolder
         mkdir python && cd python
         # Download Python source and unzip into /src subfolder
-        curl -o Python.tar.xz https://www.python.org/ftp/python/${{ env.manual-python-version }}/Python-${{ env.manual-python-version }}.tar.xz
+        curl -o Python.tar.xz https://www.python.org/ftp/python/${{ env.manual-python-version-full }}/Python-${{ env.manual-python-version-full }}.tar.xz
         mkdir src
         tar -xf Python.tar.xz -C ./src
         # All the source code is annoyingly in e.g. /src/Python-3.9.0/ or similar, so let's
@@ -61,55 +62,20 @@ jobs:
         ./configure --enable-optimizations --enable-framework --with-openssl=$(brew --prefix openssl) "--prefix=$(pwd)/build"
         make -j2
         sudo make install
-        brew install coreutils
-        echo "DID MAKE ALTINSTALL -- HERE'S SOME THINGS:"
-        echo $(pwd)
-        python -c "import os; print(os.path.realpath('.'))"
-        echo "BEGIN LS"
-        ls .
-        echo "-------------------- A"
-        python -c "import os; print(os.path.realpath('./build'))"
-        echo "BEGIN LS"
-        ls ./build
-        echo "-------------------- B"
-        python -c "import os; print(os.path.realpath('./build/bin'))"
-        echo "BEGIN LS"
-        ls ./build/bin
-        echo "-------------------- C"
-        python -c "import os; print(os.path.realpath('./build/bin/python3'))"
-        greadlink -f ./build/bin/python3
-        python -c "import os; print(os.path.realpath('./build/bin/python3.9'))"
-        greadlink -f ./build/bin/python3.9
-        echo "END ALL"
         cd ..
     - name: Copy Python for caching (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
-        cp -r /Library/Frameworks/Python.framework/Versions/3.9 ./python-framework
+        cp -r /Library/Frameworks/Python.framework/Versions/${{ env.manual-python-version }} ./python-framework
     - name: Un-copy Python from cache (macOS, cache hit)
       if: ${{ matrix.platform == 'macos-latest' && steps.caching.outputs.cache-hit }}
       run: |
         sudo mkdir /Library/Frameworks/Python.framework
         sudo mkdir /Library/Frameworks/Python.framework/Versions
-        sudo cp -r ./python-framework /Library/Frameworks/Python.framework/Versions/3.9
-        echo "DEBUG: LS"
-        ls /Library/Frameworks/Python.framework/Versions/3.9
+        sudo cp -r ./python-framework /Library/Frameworks/Python.framework/Versions/${{ env.manual-python-version }}
     - name: Make Python symlink (macOS)
       if: ${{ matrix.platform == 'macos-latest' }}
-      run: |
-        echo "ls .:"
-        ls .
-        echo "ls python:"
-        ls python
-        echo "ls python/build/bin:"
-        ls python/build/bin
-        echo "some more stuff:"
-        echo $(pwd)
-        echo $(greadlink -f ./python/build/bin/python3)
-        echo "making symlink:"
-        ln -s ./python/build/bin/python3 ./python3
-        echo "testing symlink:"
-        ./python3 -c "import sys; print(sys.version)"
+      run: ln -s ./python/build/bin/python3 ./python3
     - name: Set up Python (Windows/Linux)
       if: ${{ matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest' }}
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,6 @@ jobs:
       run: echo "PYTHON_CMD=./python3" >> $GITHUB_ENV
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Prepare for cache restoration (macOS)
-      if: ${{ matrix.platform == 'macos-latest' }}
-      run: |
-        mkdir /Library/Frameworks/Python.framework
-        mkdir /Library/Frameworks/Python.framework/Versions
-        mkdir /Library/Frameworks/Python.framework/Versions/3.9
     - name: Cache Python build (macOS)
       id: caching
       if: ${{ matrix.platform == 'macos-latest' }}
@@ -41,7 +35,7 @@ jobs:
       with:
         path: |
           ./python
-          /Library/Frameworks/Python.framework/Versions/3.9
+          ./python-framework
         key: macos-python-${{ env.manual-python-version }}-AAA
     - name: Download Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
@@ -88,6 +82,18 @@ jobs:
         greadlink -f ./build/bin/python3.9
         echo "END ALL"
         cd ..
+    - name: Copy Python for caching (macOS)
+      if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
+      run: |
+        cp -r /Library/Frameworks/Python.framework/Versions/3.9 ./python-framework
+    - name: Un-copy Python from cache (macOS)
+      if: ${{ matrix.platform == 'macos-latest' && steps.caching.outputs.cache-hit }}
+      run: |
+        sudo mkdir /Library/Frameworks/Python.framework
+        sudo mkdir /Library/Frameworks/Python.framework/Versions
+        sudo cp -r ./python-framework /Library/Frameworks/Python.framework/Versions/3.9
+        echo "DEBUG: LS"
+        ls /Library/Frameworks/Python.framework/Versions/3.9
     - name: Make Python symlink (macOS)
       if: ${{ matrix.platform == 'macos-latest' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         path: |
           ./python
           ./python-framework
-          ~/Library/Python/3.9
+          ~/Library/Python/${{ env.manual-python-version }}
         key: macos-python-${{ env.manual-python-version-full }}
     - name: Download Python (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           ./python
           ./python-framework
         key: macos-python-${{ env.manual-python-version }}-AAB
-    - name: Download Python (macOS)
+    - name: Download Python (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         # Do all this in a "python" subfolder
@@ -51,7 +51,7 @@ jobs:
         cd src
         cd *
         mv ./* ../../
-    - name: Build Python (macOS)
+    - name: Build Python (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         cd python
@@ -82,11 +82,11 @@ jobs:
         greadlink -f ./build/bin/python3.9
         echo "END ALL"
         cd ..
-    - name: Copy Python for caching (macOS)
+    - name: Copy Python for caching (macOS, cache miss)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         cp -r /Library/Frameworks/Python.framework/Versions/3.9 ./python-framework
-    - name: Un-copy Python from cache (macOS)
+    - name: Un-copy Python from cache (macOS, cache hit)
       if: ${{ matrix.platform == 'macos-latest' && steps.caching.outputs.cache-hit }}
       run: |
         sudo mkdir /Library/Frameworks/Python.framework

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,12 @@ jobs:
       run: echo "PYTHON_CMD=./python3" >> $GITHUB_ENV
     - name: Checkout repository
       uses: actions/checkout@v2
+    - name: Prepare for cache restoration (macOS)
+      if: ${{ matrix.platform == 'macos-latest' }}
+      run: |
+        mkdir /Library/Frameworks/Python.framework
+        mkdir /Library/Frameworks/Python.framework/Versions
+        mkdir /Library/Frameworks/Python.framework/Versions/3.9
     - name: Cache Python build (macOS)
       id: caching
       if: ${{ matrix.platform == 'macos-latest' }}
@@ -59,7 +65,7 @@ jobs:
         brew install openssl
         export MACOSX_DEPLOYMENT_TARGET=10.13
         ./configure --enable-optimizations --enable-framework --with-openssl=$(brew --prefix openssl) "--prefix=$(pwd)/build"
-        make
+        make -j2
         sudo make install
         brew install coreutils
         echo "DID MAKE ALTINSTALL -- HERE'S SOME THINGS:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,8 @@ jobs:
       shell: bash
       run: |
         $PYTHON_CMD -m pip install PyInstaller
-    - name: Build and install PyInstaller (macOS)
-      if: ${{ matrix.platform == 'macos-latest' }}
+    - name: Build and install PyInstaller (macOS, cache miss)
+      if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |
         git clone https://github.com/pyinstaller/pyinstaller
         cd pyinstaller/bootloader

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         path: |
           ./python
           ./python-framework
-        key: macos-python-${{ env.manual-python-version }}-AAA
+        key: macos-python-${{ env.manual-python-version }}-AAB
     - name: Download Python (macOS)
       if: ${{ matrix.platform == 'macos-latest' && !steps.caching.outputs.cache-hit }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         ./configure --enable-optimizations --enable-framework --with-openssl=$(brew --prefix openssl) "--prefix=$(pwd)/build"
         make
         sudo make altinstall
+        brew install coreutils
         echo "DID MAKE ALTINSTALL -- HERE'S SOME THINGS:"
         echo $(pwd)
         python -c "import os; print(os.path.realpath('.'))"
@@ -74,6 +75,7 @@ jobs:
         ls ./build/bin
         echo "-------------------- C"
         python -c "import os; print(os.path.realpath('./build/bin/python3'))"
+        greadlink -f ./build/bin/python3
         echo "END ALL"
         cd ..
     - name: Make Python symlink (macOS)


### PR DESCRIPTION
This commit introduces caching for Python and PyInstaller on macOS. This saves anywhere from 5-30 minutes per build (GHA's speed varies wildly based on time of day). Also, a few other small changes, such as using `make -j2` when we experience a cache miss and have to build Python manually, and moving the "if" rules from the bottom to near the top of each step definition.